### PR TITLE
chore: bump version to "0.1.0rc0"

### DIFF
--- a/anfis_toolbox/__init__.py
+++ b/anfis_toolbox/__init__.py
@@ -1,6 +1,6 @@
 """ANFIS Toolbox - A Python toolbox for Adaptive Neuro-Fuzzy Inference Systems."""
 
-__version__ = "0.1.0.dev0"
+__version__ = "0.1.0rc0"
 
 # Expose high-level estimators
 from .classifier import ANFISClassifier


### PR DESCRIPTION
This pull request updates the version number of the ANFIS Toolbox in preparation for a release candidate.

Versioning:

* Updated the `__version__` in `anfis_toolbox/__init__.py` from `"0.1.0.dev0"` to `"0.1.0rc0"` to indicate a release candidate version.